### PR TITLE
Include vendor.oneplus.hardware.display@1.0

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -261,6 +261,7 @@ PRODUCT_PACKAGES += \
     vendor.display.config@1.9.vendor \
     vendor.display.config@2.0 \
     vendor.display.config@2.0.vendor \
+    vendor.oneplus.hardware.display@1.0 \
     vendor.oneplus.hardware.display@1.0.vendor \
     vendor.qti.hardware.display.allocator-service \
     vendor.qti.hardware.display.composer-service \

--- a/overlay/packages/apps/Settings/res/values/config.xml
+++ b/overlay/packages/apps/Settings/res/values/config.xml
@@ -21,4 +21,8 @@
     <!-- Whether to show Smooth Display feature in Settings Options -->
     <bool name="config_show_smooth_display">true</bool>
 
+    <bool name="config_show_min_refresh_rate_switch">true</bool>
+
+    <bool name="config_show_max_refresh_rate_switch">true</bool>
+
 </resources>


### PR DESCRIPTION
- Without this, aosp display modes won't apply:
E qdmetadata: paramType 32 not supported